### PR TITLE
No longer force casting attribute values to prevent a crash when the …

### DIFF
--- a/Sources/UIElement.swift
+++ b/Sources/UIElement.swift
@@ -178,7 +178,11 @@ open class UIElement {
             throw error
         }
 
-        return (unpackAXValue(value!) as! T)
+        guard let unpackedValue = (unpackAXValue(value!) as? T) else {
+            throw AXError.illegalArgument
+        }
+        
+        return unpackedValue
     }
 
     /// Sets the value of `attribute` to `value`.


### PR DESCRIPTION
…value doesn't match the expected type

This can happen under 2 circumstances:

1) If a developer mistakingly uses the wrong type when trying to retrieve an attribute
```
let title: NSNumber = try? attribute(.title)
```

2) The value from the window isn't the expected type. As an example, windows from most apps that I've interacted with have an `identifier` of type `String`, but OmniFocus's main window has an `identifier` that is of type `NSNumber`.  