### PR TITLE
Add focused tab and load complete notifications

### DIFF
--- a/Sources/Constants.swift
+++ b/Sources/Constants.swift
@@ -5,6 +5,7 @@ public enum AXNotification: String {
     case mainWindowChanged       = "AXMainWindowChanged"
     case focusedWindowChanged    = "AXFocusedWindowChanged"
     case focusedUIElementChanged = "AXFocusedUIElementChanged"
+    case focusedTabChanged       = "AXFocusedTabChanged"
 
     // Application notifications
     case applicationActivated    = "AXApplicationActivated"
@@ -43,6 +44,7 @@ public enum AXNotification: String {
     case selectedChildrenChanged = "AXSelectedChildrenChanged"
     case selectedRowsChanged     = "AXSelectedRowsChanged"
     case selectedColumnsChanged  = "AXSelectedColumnsChanged"
+    case loadComplete            = "AXLoadComplete"
 
     case rowExpanded             = "AXRowExpanded"
     case rowCollapsed            = "AXRowCollapsed"


### PR DESCRIPTION
The first one is triggered when changing the focused tab (fired at least in Finder and Webkit based browsers), and the second is at least fired in Webkit based browsers when the page has loaded.